### PR TITLE
[frameworks_base] Settings: Add @hide javadoc comment to BUTTON_BACKLIGHT_ONLY_WHEN_PRE…

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -4482,6 +4482,7 @@ public final class Settings {
         /**
          * Whether the button backlight is only lit when pressed (and not when screen is touched)
          * The value is boolean (1 or 0).
+         * @hide
          */
         public static final String BUTTON_BACKLIGHT_ONLY_WHEN_PRESSED =
                 "button_backlight_only_when_pressed";


### PR DESCRIPTION
Address the error below to fix the build.

Settings.java:4482: error: Added field
android.provider.Settings.System.BUTTON_BACKLIGHT_ONLY_WHEN_PRESSED [AddedField]
Aborting: Found compatibility problems checking the public API against the API [......]