### PR TITLE
Fix crash on some devices by checking for null client

### DIFF
--- a/services/core/java/com/android/server/biometrics/BiometricServiceBase.java
+++ b/services/core/java/com/android/server/biometrics/BiometricServiceBase.java
@@ -795,6 +795,7 @@ public abstract class BiometricServiceBase extends SystemService
     protected void handleEnumerate(BiometricAuthenticator.Identifier identifier, int remaining) {
         ClientMonitor client = getCurrentClient();
 
+        if(client == null) return;
         client.onEnumerationResult(identifier, remaining);
 
         // All templates in the HAL for this user were enumerated


### PR DESCRIPTION
```
Some device get the following system_server crash:
 *** FATAL EXCEPTION IN SYSTEM PROCESS: main
 java.lang.NullPointerException: Attempt to invoke virtual method 'boolean com.android.server.biometrics.ClientMonitor.onEnumerationResult(android.hardware.biometrics.BiometricAuthenticator$Identifier, int)' on a null object reference
        at com.android.server.biometrics.BiometricServiceBase.handleEnumerate(BiometricServiceBase.java:777)
        at com.android.server.biometrics.fingerprint.FingerprintService.access$6901(FingerprintService.java:93)
        at com.android.server.biometrics.fingerprint.FingerprintService$1.lambda$onEnumerate$5$FingerprintService$1(FingerprintService.java:686)
        at com.android.server.biometrics.fingerprint.-$$Lambda$FingerprintService$1$3I9ge5BoesXZUovbayCOCR754fc.run(Unknown Source:10)

Fix it by checking for `null` client before acting on it
```