### PR TITLE
FODCircleView: Support dim behind pressed layer

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
@@ -344,7 +344,8 @@ public class FODCircleView extends ImageView implements ConfigurationListener {
         mParams.type = WindowManager.LayoutParams.TYPE_DISPLAY_OVERLAY;
         mParams.flags = WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE |
                 WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN |
-                WindowManager.LayoutParams.FLAG_WATCH_OUTSIDE_TOUCH;
+                WindowManager.LayoutParams.FLAG_WATCH_OUTSIDE_TOUCH |
+                WindowManager.LayoutParams.FLAG_DIM_BEHIND;
         mParams.gravity = Gravity.TOP | Gravity.LEFT;
 
         mPressedParams.copyFrom(mParams);
@@ -353,6 +354,8 @@ public class FODCircleView extends ImageView implements ConfigurationListener {
 
         mParams.setTitle("Fingerprint on display");
         mPressedParams.setTitle("Fingerprint on display.touched");
+        
+        mParams.dimAmount = 0.0f;
 
         mPressedView = new ImageView(context)  {
             @Override


### PR DESCRIPTION
* This will fix problem onTouch of apparently boost brightness for Xiaomi Displayfeature FOD implementation

Credits go to:
https://review.lineageos.org/c/LineageOS/android_frameworks_base/+/311759/1