### PR TITLE
[fix] : TaskSnapshot  release child layer

### DIFF
--- a/libs/WindowManager/Shell/src/com/android/wm/shell/startingsurface/TaskSnapshotWindow.java
+++ b/libs/WindowManager/Shell/src/com/android/wm/shell/startingsurface/TaskSnapshotWindow.java
@@ -382,6 +382,7 @@ public class TaskSnapshotWindow {
 
         // In case window manager leaks us, make sure we don't retain the snapshot.
         mSnapshot = null;
+        mSurfaceControl.release();
     }
 
     private void drawSizeMatchSnapshot() {
@@ -449,6 +450,7 @@ public class TaskSnapshotWindow {
             mTransaction.setBuffer(mSurfaceControl, background);
         }
         mTransaction.apply();
+        childSurfaceControl.release();
     }
 
     /**


### PR DESCRIPTION
TaskSnapshot Window is left as offscreen layer in SurfaceFlinger so release it manually