### PR TITLE
DisplayPowerController: Don't apply brightness adjustment if NaN

### DIFF
--- a/services/core/java/com/android/server/display/DisplayPowerController.java
+++ b/services/core/java/com/android/server/display/DisplayPowerController.java
@@ -2530,6 +2530,8 @@ final class DisplayPowerController implements AutomaticBrightnessController.Call
     }
 
     private void putAutoBrightnessAdjustmentSetting(float adjustment) {
+        if (Float.isNaN(adjustment))
+            return;
         if (mDisplayId == Display.DEFAULT_DISPLAY) {
             mAutoBrightnessAdjustment = adjustment;
             Settings.System.putFloatForUser(mContext.getContentResolver(),


### PR DESCRIPTION
On some devices, old incompatible brightness configs are causing PowerManager to crash randomly although auto brightness seems working just all fine.